### PR TITLE
Don't pass name/address as NSPrint format string

### DIFF
--- a/bluectl.m
+++ b/bluectl.m
@@ -76,11 +76,11 @@ int main(int argc, char const * argv[]) {
     }
 
     if ([command isEqualToString:@"name"]) {
-        NSPrint([device name]);
+        NSPrint(@"%@", [device name]);
     }
 
     if ([command isEqualToString:@"address"]) {
-        NSPrint([device addressString]);
+        NSPrint(@"%@", [device addressString]);
     }
 
     if ([command isEqualToString:@"connect"]) {


### PR DESCRIPTION
`bluectl` crashes if you ask for the name of a device that doesn't have one:

```
kahekkass ~/Code/vilhalmer/bluectl master$ ./bluectl
Paired devices:

(null) (08-66-98-a1-25-12)
kahekkass ~/Code/vilhalmer/bluectl master$ ./bluectl 08-66-98-a1-25-12 name
2017-03-27 08:32:14.418 bluectl[3708:103878] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[NSPl
aceholderString initWithFormat:locale:arguments:]: nil argument'
*** First throw call stack:
(
        0   CoreFoundation                      0x00007fff957f6e7b __exceptionPreprocess + 171
        1   libobjc.A.dylib                     0x00007fffaa3d6cad objc_exception_throw + 48
        2   CoreFoundation                      0x00007fff9587599d +[NSException raise:format:] + 205
        3   Foundation                          0x00007fff97169037 -[NSPlaceholderString initWithFormat:locale:arguments:] + 115
        4   bluectl                             0x000000010d8795c8 NSPrint + 392
        5   bluectl                             0x000000010d879c6c main + 924
        6   libdyld.dylib                       0x00007fffaacba255 start + 1
        7   ???                                 0x0000000000000003 0x0 + 3
)
libc++abi.dylib: terminating with uncaught exception of type NSException
Abort trap: 6
kahekkass ~/Code/vilhalmer/bluectl master$
```

This is because we pass the name as the format string directly, leading to `[[NSString alloc] initWithFormat:nil …]`.